### PR TITLE
Version9へのアップデート

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 group = "io.trocco"
-version = "0.1.20"
+version = "0.1.21"
 description = "embulk input plugin for Google Ads"
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/shadow-google-ads-helper/build.gradle
+++ b/shadow-google-ads-helper/build.gradle
@@ -30,7 +30,7 @@ configurations {
 }
 
 dependencies {
-    compile("com.google.api-ads:google-ads:15.0.0") {
+    compile("com.google.api-ads:google-ads:16.0.3") {
         exclude group: "commons-logging", module: "commons-logging"
     }
 

--- a/src/main/java/org/embulk/input/google_ads/GoogleAdsInputPlugin.java
+++ b/src/main/java/org/embulk/input/google_ads/GoogleAdsInputPlugin.java
@@ -1,7 +1,7 @@
 package org.embulk.input.google_ads;
 
-import com.google.ads.googleads.v8.services.GoogleAdsRow;
-import com.google.ads.googleads.v8.services.GoogleAdsServiceClient;
+import com.google.ads.googleads.v9.services.GoogleAdsRow;
+import com.google.ads.googleads.v9.services.GoogleAdsServiceClient;
 import com.google.common.collect.ImmutableList;
 
 import org.embulk.config.ConfigDiff;

--- a/src/main/java/org/embulk/input/google_ads/GoogleAdsReporter.java
+++ b/src/main/java/org/embulk/input/google_ads/GoogleAdsReporter.java
@@ -74,13 +74,9 @@ public class GoogleAdsReporter
 
             if (isLeaf(attributeName)) {
                 result.put(attributeName, convertLeafNodeValue(fields, key));
-            } else {
-                if (!key.getName().equals("resource_name")) {
-                    if (fields.get(key) instanceof GeneratedMessageV3) {
-                        GeneratedMessageV3 message = (GeneratedMessageV3) fields.get(key);
-                        flattenResource(attributeName, message.getAllFields(), result);
-                    }
-                }
+            } else if (fields.get(key) instanceof GeneratedMessageV3) {
+                GeneratedMessageV3 message = (GeneratedMessageV3) fields.get(key);
+                flattenResource(attributeName, message.getAllFields(), result);
             }
         }
     }

--- a/src/main/java/org/embulk/input/google_ads/GoogleAdsReporter.java
+++ b/src/main/java/org/embulk/input/google_ads/GoogleAdsReporter.java
@@ -76,8 +76,10 @@ public class GoogleAdsReporter
                 result.put(attributeName, convertLeafNodeValue(fields, key));
             } else {
                 if (!key.getName().equals("resource_name")) {
-                    GeneratedMessageV3 message = (GeneratedMessageV3) fields.get(key);
-                    flattenResource(attributeName, message.getAllFields(), result);
+                    if (fields.get(key) instanceof GeneratedMessageV3) {
+                        GeneratedMessageV3 message = (GeneratedMessageV3) fields.get(key);
+                        flattenResource(attributeName, message.getAllFields(), result);
+                    }
                 }
             }
         }

--- a/src/main/java/org/embulk/input/google_ads/GoogleAdsReporter.java
+++ b/src/main/java/org/embulk/input/google_ads/GoogleAdsReporter.java
@@ -7,8 +7,8 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.ads.googleads.lib.GoogleAdsClient;
-import com.google.ads.googleads.v8.services.GoogleAdsServiceClient;
-import com.google.ads.googleads.v8.services.SearchGoogleAdsRequest;
+import com.google.ads.googleads.v9.services.GoogleAdsServiceClient;
+import com.google.ads.googleads.v9.services.SearchGoogleAdsRequest;
 import com.google.auth.oauth2.UserCredentials;
 import com.google.common.base.CaseFormat;
 import com.google.protobuf.Descriptors;
@@ -57,7 +57,7 @@ public class GoogleAdsReporter
         String query = buildQuery(task);
         logger.info(query);
         SearchGoogleAdsRequest request = buildRequest(task, query);
-        GoogleAdsServiceClient googleAdsService = client.getVersion8().createGoogleAdsServiceClient();
+        GoogleAdsServiceClient googleAdsService = client.getVersion9().createGoogleAdsServiceClient();
         GoogleAdsServiceClient.SearchPagedResponse response = googleAdsService.search(request);
         return response.iteratePages();
     }


### PR DESCRIPTION
# 概要
* google ads APIのv9がリリースされたため対応
* sdkは最新の16.0.3へアップデート
* buildが成功することを確認
* 動作確認はgemを作成した後に行います