### PR TITLE
Update Google Ads API to v12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id "java"
     id "checkstyle"
     id "maven-publish"
-    id "com.github.johnrengelman.shadow" version "5.2.0" apply false
+    id "com.github.johnrengelman.shadow" version "6.0.0" apply false
     id "org.embulk.embulk-plugins" version "0.4.2"
     id "com.palantir.git-version" version "0.13.0"
 }

--- a/shadow-google-ads-helper/build.gradle
+++ b/shadow-google-ads-helper/build.gradle
@@ -30,7 +30,7 @@ configurations {
 }
 
 dependencies {
-    compile("com.google.api-ads:google-ads:19.0.0") {
+    compile("com.google.api-ads:google-ads:22.0.0") {
         exclude group: "commons-logging", module: "commons-logging"
     }
 

--- a/src/main/java/org/embulk/input/google_ads/GoogleAdsInputPlugin.java
+++ b/src/main/java/org/embulk/input/google_ads/GoogleAdsInputPlugin.java
@@ -1,7 +1,7 @@
 package org.embulk.input.google_ads;
 
-import com.google.ads.googleads.v11.services.GoogleAdsRow;
-import com.google.ads.googleads.v11.services.GoogleAdsServiceClient;
+import com.google.ads.googleads.v12.services.GoogleAdsRow;
+import com.google.ads.googleads.v12.services.GoogleAdsServiceClient;
 import com.google.common.collect.ImmutableList;
 
 import org.embulk.config.ConfigDiff;

--- a/src/main/java/org/embulk/input/google_ads/GoogleAdsReporter.java
+++ b/src/main/java/org/embulk/input/google_ads/GoogleAdsReporter.java
@@ -7,8 +7,8 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.ads.googleads.lib.GoogleAdsClient;
-import com.google.ads.googleads.v11.services.GoogleAdsServiceClient;
-import com.google.ads.googleads.v11.services.SearchGoogleAdsRequest;
+import com.google.ads.googleads.v12.services.GoogleAdsServiceClient;
+import com.google.ads.googleads.v12.services.SearchGoogleAdsRequest;
 import com.google.auth.oauth2.UserCredentials;
 import com.google.common.base.CaseFormat;
 import com.google.protobuf.Descriptors;
@@ -57,7 +57,7 @@ public class GoogleAdsReporter
         String query = buildQuery(task);
         logger.info(query);
         SearchGoogleAdsRequest request = buildRequest(task, query);
-        GoogleAdsServiceClient googleAdsService = client.getVersion11().createGoogleAdsServiceClient();
+        GoogleAdsServiceClient googleAdsService = client.getVersion12().createGoogleAdsServiceClient();
         GoogleAdsServiceClient.SearchPagedResponse response = googleAdsService.search(request);
         return response.iteratePages();
     }


### PR DESCRIPTION
- Update google ads API client to support  google ads API V12.  [c24d865](https://github.com/trocco-io/embulk-input-google_ads/pull/43/commits/c24d8652d30f78471564cdc29dc22815afe01205)
- Update `com.github.johnrengelman.shadow` to build embulk-input-google-ads plugin. [012e1d5](https://github.com/trocco-io/embulk-input-google_ads/pull/43/commits/012e1d559902a5fa627378a6fdbe15a1c238d744)