### PR TITLE
bump Google Ads SDK to 0.25.0 (support for Google Ads API v13.1)

### DIFF
--- a/shadow-google-ads-helper/build.gradle
+++ b/shadow-google-ads-helper/build.gradle
@@ -30,7 +30,7 @@ configurations {
 }
 
 dependencies {
-    compile("com.google.api-ads:google-ads:22.0.0") {
+    compile("com.google.api-ads:google-ads:25.0.0") {
         exclude group: "commons-logging", module: "commons-logging"
     }
 

--- a/src/main/java/org/embulk/input/google_ads/GoogleAdsInputPlugin.java
+++ b/src/main/java/org/embulk/input/google_ads/GoogleAdsInputPlugin.java
@@ -1,7 +1,7 @@
 package org.embulk.input.google_ads;
 
-import com.google.ads.googleads.v12.services.GoogleAdsRow;
-import com.google.ads.googleads.v12.services.GoogleAdsServiceClient;
+import com.google.ads.googleads.v13.services.GoogleAdsRow;
+import com.google.ads.googleads.v13.services.GoogleAdsServiceClient;
 import com.google.common.collect.ImmutableList;
 
 import org.embulk.config.ConfigDiff;

--- a/src/main/java/org/embulk/input/google_ads/GoogleAdsReporter.java
+++ b/src/main/java/org/embulk/input/google_ads/GoogleAdsReporter.java
@@ -7,8 +7,8 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.ads.googleads.lib.GoogleAdsClient;
-import com.google.ads.googleads.v12.services.GoogleAdsServiceClient;
-import com.google.ads.googleads.v12.services.SearchGoogleAdsRequest;
+import com.google.ads.googleads.v13.services.GoogleAdsServiceClient;
+import com.google.ads.googleads.v13.services.SearchGoogleAdsRequest;
 import com.google.auth.oauth2.UserCredentials;
 import com.google.common.base.CaseFormat;
 import com.google.protobuf.Descriptors;
@@ -57,7 +57,7 @@ public class GoogleAdsReporter
         String query = buildQuery(task);
         logger.info(query);
         SearchGoogleAdsRequest request = buildRequest(task, query);
-        GoogleAdsServiceClient googleAdsService = client.getVersion12().createGoogleAdsServiceClient();
+        GoogleAdsServiceClient googleAdsService = client.getVersion13().createGoogleAdsServiceClient();
         GoogleAdsServiceClient.SearchPagedResponse response = googleAdsService.search(request);
         return response.iteratePages();
     }


### PR DESCRIPTION
Google Ads API v12 is [reaching EOL](https://developers.google.com/google-ads/api/docs/sunset-dates), so upgrading the SDK version to [0.25.0](https://github.com/googleads/google-ads-java/releases/tag/25.0.0).