### PR TITLE
Get login customer id with customer id

### DIFF
--- a/src/main/java/org/embulk/input/google_ads/GoogleAdsReporter.java
+++ b/src/main/java/org/embulk/input/google_ads/GoogleAdsReporter.java
@@ -297,9 +297,11 @@ public class GoogleAdsReporter
             throw new RuntimeException("login customer not found [customer id: " + customerId + "]");
         }
         if (loginCustomerIds.size() > 1) {
-            logger.warn("ambiguous login customers found [customer id: {}, login customer ids: {}]", customerId, loginCustomerIds.stream().map(Object::toString).collect(Collectors.joining(", ")));
+            logger.info("multiple login customers found [login customer ids: {}]", loginCustomerIds.stream().map(Object::toString).collect(Collectors.joining(", ")));
         }
-        return loginCustomerIds.get(0);
+        Long loginCustomerId = loginCustomerIds.get(0);
+        logger.info("use this customer [customer id: {}, login customer id: {}] to login", customerId, loginCustomerId);
+        return loginCustomerId;
     }
 
     private List<Long> getLoginCustomerIds(String customerId)

--- a/src/main/java/org/embulk/input/google_ads/GoogleAdsReporter.java
+++ b/src/main/java/org/embulk/input/google_ads/GoogleAdsReporter.java
@@ -309,7 +309,7 @@ public class GoogleAdsReporter
 
     private List<LoginCustomerClient> getLoginCustomerClients(String customerId)
     {
-        try (GoogleAdsServiceClient client = buildClient(null).getLatestVersion().createGoogleAdsServiceClient()) {
+        try (GoogleAdsServiceClient client = buildClient(Long.valueOf(customerId)).getLatestVersion().createGoogleAdsServiceClient()) {
             return client.searchStreamCallable().call(SearchGoogleAdsStreamRequest.newBuilder()
                             .setCustomerId(customerId)
                             .setQuery("SELECT customer_client.id, customer_client.manager FROM customer_client")

--- a/src/main/java/org/embulk/input/google_ads/PluginTask.java
+++ b/src/main/java/org/embulk/input/google_ads/PluginTask.java
@@ -15,7 +15,7 @@ public interface PluginTask extends Task
 
     @Config("login_customer_id")
     @ConfigDefault("null")
-    Optional<String> getLoginCustomerId();
+    Optional<Long> getLoginCustomerId();
 
     @Config("client_id")
     String getClientId();


### PR DESCRIPTION
<details>
<summary>config.yml</summary>

```
$ cat config.yml
in:
  type: google_ads
  customer_id: 6797712831
  client_id: ***
  client_secret: ***
  refresh_token: ***
  developer_token: ***
  resource_type: customer
  daterange:
    start_date: '2021-01-01'
    end_date: '2021-01-07'
  fields:
  - name: customer.id
    type: long
  - name: segments.ad_network_type
    type: string
  - name: segments.date
    type: string
  - name: segments.device
    type: string
  - name: metrics.active_view_impressions
    type: long
  - name: metrics.active_view_measurability
    type: double
  - name: metrics.active_view_measurable_cost_micros
    type: long
  - name: metrics.active_view_measurable_impressions
    type: long
  - name: metrics.active_view_viewability
    type: double
  - name: metrics.clicks
    type: long
  - name: metrics.conversions
    type: double
  - name: metrics.conversions_value
    type: double
  - name: metrics.cost_micros
    type: long
  - name: metrics.impressions
    type: long
  - name: metrics.interaction_event_types
    type: json
  - name: metrics.interactions
    type: long
  - name: metrics.view_through_conversions
    type: long
out:
  type: command
  command: 'cat -'
  formatter:
    type: jsonl
```

</details>
<details>
<summary>embulk run</summary>

```
$ embulk run config.yml
2024-08-14 01:32:19.920 +0000: Embulk v0.9.26
2024-08-14 01:32:20.706 +0000 [WARN] (main): DEPRECATION: JRuby org.jruby.embed.ScriptingContainer is directly injected.
2024-08-14 01:32:22.215 +0000 [INFO] (main): Gem's home and path are set by default: "/home/ubuntu/.embulk/lib/gems"
2024-08-14 01:32:22.984 +0000 [INFO] (main): Started Embulk v0.9.26
2024-08-14 01:32:23.101 +0000 [INFO] (0001:transaction): Loaded plugin embulk-input-google_ads (0.1.29)
2024-08-14 01:32:23.131 +0000 [INFO] (0001:transaction): Loaded plugin embulk-output-command (0.1.4)
2024-08-14 01:32:23.158 +0000 [INFO] (0001:transaction): Using local thread executor with max_threads=16 / output tasks 8 = input tasks 1 * 8
2024-08-14 01:32:23.210 +0000 [INFO] (0001:transaction): Loaded plugin embulk-formatter-jsonl (0.1.4)
2024-08-14 01:32:23.243 +0000 [INFO] (0001:transaction): {done:  0 / 1, running: 0}
2024-08-14 01:32:23.253 +0000 [INFO] (0015:task-0000): Using command [sh, -c, cat -]
2024-08-14 01:32:23.271 +0000 [INFO] (0015:task-0000): Using command [sh, -c, cat -]
2024-08-14 01:32:23.276 +0000 [INFO] (0015:task-0000): Using command [sh, -c, cat -]
2024-08-14 01:32:23.283 +0000 [INFO] (0015:task-0000): Using command [sh, -c, cat -]
2024-08-14 01:32:23.289 +0000 [INFO] (0015:task-0000): Using command [sh, -c, cat -]
2024-08-14 01:32:23.293 +0000 [INFO] (0015:task-0000): Using command [sh, -c, cat -]
2024-08-14 01:32:23.297 +0000 [INFO] (0015:task-0000): Using command [sh, -c, cat -]
2024-08-14 01:32:23.301 +0000 [INFO] (0015:task-0000): Using command [sh, -c, cat -]
2024-08-14 01:32:24.606 +0000 [INFO] (grpc-default-executor-0): SUCCESS REQUEST SUMMARY. Method: google.ads.googleads.v16.services.CustomerService/ListAccessibleCustomers, Endpoint: googleads.googleapis.com:443, CustomerID: null, RequestID: cE7TIY1UASkY8NDnSfZ_Cw, ResponseCode: OK, Fault: null.
2024-08-14 01:32:25.714 +0000 [INFO] (grpc-default-executor-2): SUCCESS REQUEST SUMMARY. Method: google.ads.googleads.v16.services.GoogleAdsService/SearchStream, Endpoint: googleads.googleapis.com:443, CustomerID: 9063267992, RequestID: XK8vtrvo7xwDeroBbonOew, ResponseCode: OK, Fault: null.
2024-08-14 01:32:26.287 +0000 [INFO] (grpc-default-executor-1): SUCCESS REQUEST SUMMARY. Method: google.ads.googleads.v16.services.GoogleAdsService/SearchStream, Endpoint: googleads.googleapis.com:443, CustomerID: 3582290452, RequestID: BQ6KqgIINJFNEkzdOqvslQ, ResponseCode: OK, Fault: null.
2024-08-14 01:32:26.807 +0000 [INFO] (grpc-default-executor-0): SUCCESS REQUEST SUMMARY. Method: google.ads.googleads.v16.services.GoogleAdsService/SearchStream, Endpoint: googleads.googleapis.com:443, CustomerID: 8101582731, RequestID: lYf744JjbzmtmoF6myHmow, ResponseCode: OK, Fault: null.
2024-08-14 01:32:26.810 +0000 [INFO] (0015:task-0000): multiple login customers found [login customer ids: 9063267992, 3582290452]
2024-08-14 01:32:26.810 +0000 [INFO] (0015:task-0000): use this customer [customer id: 6797712831, login customer id: 9063267992] to login
2024-08-14 01:32:26.830 +0000 [INFO] (0015:task-0000): SELECT customer.id, segments.ad_network_type, segments.date, segments.device, metrics.active_view_impressions, metrics.active_view_measurability, metrics.active_view_measurable_cost_micros, metrics.active_view_measurable_impressions, metrics.active_view_viewability, metrics.clicks, metrics.conversions, metrics.conversions_value, metrics.cost_micros, metrics.impressions, metrics.interaction_event_types, metrics.interactions, metrics.view_through_conversions FROM customer WHERE segments.date BETWEEN '2021-01-01' AND '2021-01-07'
2024-08-14 01:32:27.675 +0000 [INFO] (grpc-default-executor-2): SUCCESS REQUEST SUMMARY. Method: google.ads.googleads.v16.services.GoogleAdsService/Search, Endpoint: googleads.googleapis.com:443, CustomerID: 6797712831, RequestID: k8n8E0gkd2A9uMxrctol7w, ResponseCode: OK, Fault: null.
{"customer.id":6797712831,"segments.ad_network_type":"SEARCH","segments.date":"2021-01-07","segments.device":"DESKTOP","metrics.active_view_impressions":0,"metrics.active_view_measurability":0.0,"metrics.active_view_measurable_cost_micros":0,"metrics.active_view_measurable_impressions":0,"metrics.active_view_viewability":null,"metrics.clicks":12,"metrics.conversions":0.0,"metrics.conversions_value":0.0,"metrics.cost_micros":4781000000,"metrics.impressions":597,"metrics.interaction_event_types":["CLICK"],"metrics.interactions":12,"metrics.view_through_conversions":0}
{"customer.id":6797712831,"segments.ad_network_type":"SEARCH","segments.date":"2021-01-07","segments.device":"MOBILE","metrics.active_view_impressions":0,"metrics.active_view_measurability":0.0,"metrics.active_view_measurable_cost_micros":0,"metrics.active_view_measurable_impressions":0,"metrics.active_view_viewability":null,"metrics.clicks":5,"metrics.conversions":0.0,"metrics.conversions_value":0.0,"metrics.cost_micros":2989000000,"metrics.impressions":238,"metrics.interaction_event_types":["CLICK"],"metrics.interactions":5,"metrics.view_through_conversions":0}
{"customer.id":6797712831,"segments.ad_network_type":"SEARCH","segments.date":"2021-01-07","segments.device":"TABLET","metrics.active_view_impressions":0,"metrics.active_view_measurability":0.0,"metrics.active_view_measurable_cost_micros":0,"metrics.active_view_measurable_impressions":0,"metrics.active_view_viewability":null,"metrics.clicks":0,"metrics.conversions":0.0,"metrics.conversions_value":0.0,"metrics.cost_micros":0,"metrics.impressions":20,"metrics.interaction_event_types":null,"metrics.interactions":0,"metrics.view_through_conversions":0}
{"customer.id":6797712831,"segments.ad_network_type":"SEARCH_PARTNERS","segments.date":"2021-01-07","segments.device":"DESKTOP","metrics.active_view_impressions":0,"metrics.active_view_measurability":0.0,"metrics.active_view_measurable_cost_micros":0,"metrics.active_view_measurable_impressions":0,"metrics.active_view_viewability":null,"metrics.clicks":0,"metrics.conversions":0.0,"metrics.conversions_value":0.0,"metrics.cost_micros":0,"metrics.impressions":38,"metrics.interaction_event_types":null,"metrics.interactions":0,"metrics.view_through_conversions":0}
{"customer.id":6797712831,"segments.ad_network_type":"SEARCH_PARTNERS","segments.date":"2021-01-07","segments.device":"MOBILE","metrics.active_view_impressions":0,"metrics.active_view_measurability":0.0,"metrics.active_view_measurable_cost_micros":0,"metrics.active_view_measurable_impressions":0,"metrics.active_view_viewability":null,"metrics.clicks":0,"metrics.conversions":0.0,"metrics.conversions_value":0.0,"metrics.cost_micros":0,"metrics.impressions":87,"metrics.interaction_event_types":null,"metrics.interactions":0,"metrics.view_through_conversions":0}
{"customer.id":6797712831,"segments.ad_network_type":"SEARCH_PARTNERS","segments.date":"2021-01-07","segments.device":"TABLET","metrics.active_view_impressions":0,"metrics.active_view_measurability":0.0,"metrics.active_view_measurable_cost_micros":0,"metrics.active_view_measurable_impressions":0,"metrics.active_view_viewability":null,"metrics.clicks":0,"metrics.conversions":0.0,"metrics.conversions_value":0.0,"metrics.cost_micros":0,"metrics.impressions":4,"metrics.interaction_event_types":null,"metrics.interactions":0,"metrics.view_through_conversions":0}
{"customer.id":6797712831,"segments.ad_network_type":"CONTENT","segments.date":"2021-01-07","segments.device":"DESKTOP","metrics.active_view_impressions":271,"metrics.active_view_measurability":0.8975409836065574,"metrics.active_view_measurable_cost_micros":164713343,"metrics.active_view_measurable_impressions":657,"metrics.active_view_viewability":0.4124809741248097,"metrics.clicks":2,"metrics.conversions":0.0,"metrics.conversions_value":0.0,"metrics.cost_micros":164713343,"metrics.impressions":732,"metrics.interaction_event_types":["CLICK"],"metrics.interactions":2,"metrics.view_through_conversions":0}
{"customer.id":6797712831,"segments.ad_network_type":"CONTENT","segments.date":"2021-01-07","segments.device":"MOBILE","metrics.active_view_impressions":264,"metrics.active_view_measurability":0.8923679060665362,"metrics.active_view_measurable_cost_micros":213585174,"metrics.active_view_measurable_impressions":456,"metrics.active_view_viewability":0.5789473684210527,"metrics.clicks":3,"metrics.conversions":0.0,"metrics.conversions_value":0.0,"metrics.cost_micros":213585174,"metrics.impressions":511,"metrics.interaction_event_types":["CLICK"],"metrics.interactions":3,"metrics.view_through_conversions":0}
{"customer.id":6797712831,"segments.ad_network_type":"CONTENT","segments.date":"2021-01-07","segments.device":"TABLET","metrics.active_view_impressions":19,"metrics.active_view_measurability":1.0,"metrics.active_view_measurable_cost_micros":0,"metrics.active_view_measurable_impressions":26,"metrics.active_view_viewability":0.7307692307692307,"metrics.clicks":0,"metrics.conversions":0.0,"metrics.conversions_value":0.0,"metrics.cost_micros":0,"metrics.impressions":26,"metrics.interaction_event_types":null,"metrics.interactions":0,"metrics.view_through_conversions":0}
2024-08-14 01:32:28.093 +0000 [INFO] (0001:transaction): {done:  1 / 1, running: 0}
2024-08-14 01:32:28.097 +0000 [INFO] (main): Committed.
2024-08-14 01:32:28.097 +0000 [INFO] (main): Next config diff: {"in":{},"out":{}}
```

</details>