### PR TITLE
removed page size parameter

### DIFF
--- a/src/main/java/org/embulk/input/google_ads/GoogleAdsReporter.java
+++ b/src/main/java/org/embulk/input/google_ads/GoogleAdsReporter.java
@@ -33,7 +33,6 @@ import java.util.stream.Stream;
 
 public class GoogleAdsReporter
 {
-    private static final int PAGE_SIZE = 1000;
     private final Logger logger = LoggerFactory.getLogger(GoogleAdsReporter.class);
     private final PluginTask task;
     private final UserCredentials credentials;
@@ -223,7 +222,6 @@ public class GoogleAdsReporter
     {
         return SearchGoogleAdsRequest.newBuilder()
                 .setCustomerId(task.getCustomerId())
-                .setPageSize(PAGE_SIZE)
                 .setQuery(query)
                 .build();
     }


### PR DESCRIPTION
google ads api returns following error.
```
query: "SELECT change_event.resource_name, change_event.change_date_time FROM change_event WHERE change_event.change_date_time  >= \'2020-01-01\' AND change_event.change_date_time  <= \'2020-12-01\' ORDER BY change_event.change_date_time ASC LIMIT 100000"
page_size: 1000


Response
--------
Headers: Metadata(content-type=application/grpc,request-id=_gSmphNIP-ezuEGckQWUuA,date=Fri, 23 Aug 2024 01:23:36 GMT,alt-svc=h3=":443"; ma=2592000,h3-29=":443"; ma=2592000)
Body: null
Failure message: errors {
  error_code {
    request_error: INVALID_PAGE_SIZE
  }
  message: "Page size is invalid."
}
request_id: "_gSmphNIP-ezuEGckQWUuA"
```

This seems to be the effect of [this change](https://ads-developers.googleblog.com/2024/07/upcoming-changes-to-page-size-in-google.html).