### PR TITLE
Fix null data caused by protobuf 4.x GeneratedMessageV3 incompatibility

### DIFF
--- a/src/main/java/org/embulk/input/google_ads/GoogleAdsReporter.java
+++ b/src/main/java/org/embulk/input/google_ads/GoogleAdsReporter.java
@@ -21,7 +21,7 @@ import com.google.api.gax.rpc.PermissionDeniedException;
 import com.google.auth.oauth2.UserCredentials;
 import com.google.common.base.CaseFormat;
 import com.google.protobuf.Descriptors;
-import com.google.protobuf.GeneratedMessageV3;
+import com.google.protobuf.AbstractMessage;
 import com.google.protobuf.util.JsonFormat;
 
 import org.embulk.util.config.units.ColumnConfig;
@@ -109,8 +109,8 @@ public class GoogleAdsReporter
 
             if (isLeaf(attributeName)) {
                 result.put(attributeName, convertLeafNodeValue(fields, key));
-            } else if (fields.get(key) instanceof GeneratedMessageV3) {
-                GeneratedMessageV3 message = (GeneratedMessageV3) fields.get(key);
+            } else if (fields.get(key) instanceof AbstractMessage) {
+                AbstractMessage message = (AbstractMessage) fields.get(key);
                 flattenResource(attributeName, message.getAllFields(), result);
             }
         }
@@ -199,9 +199,9 @@ public class GoogleAdsReporter
     {
         if (key.isRepeated()) {
             ArrayNode result = mapper.createArrayNode();
-            List<GeneratedMessageV3> field = (List<GeneratedMessageV3>) fields.get(key);
+            List<AbstractMessage> field = (List<AbstractMessage>) fields.get(key);
             try {
-                for (GeneratedMessageV3 msg : field) {
+                for (AbstractMessage msg : field) {
                     JsonNode jsonNode = mapper.readTree(JsonFormat.printer().print(msg));
                     JsonNode jsonNodeWithSnakeCase = traverse(jsonNode);
                     result.add(jsonNodeWithSnakeCase);
@@ -213,7 +213,7 @@ public class GoogleAdsReporter
             }
         } else {
             try {
-                String jsonStr = JsonFormat.printer().print((GeneratedMessageV3) fields.get(key));
+                String jsonStr = JsonFormat.printer().print((AbstractMessage) fields.get(key));
                 JsonNode jsonNode = mapper.readTree(jsonStr);
                 JsonNode jsonNodeWithSnakeCase = traverse(jsonNode);
                 return mapper.writeValueAsString(jsonNodeWithSnakeCase);

--- a/src/main/java/org/embulk/input/google_ads/GoogleAdsReporter.java
+++ b/src/main/java/org/embulk/input/google_ads/GoogleAdsReporter.java
@@ -20,8 +20,8 @@ import com.google.api.gax.rpc.DeadlineExceededException;
 import com.google.api.gax.rpc.PermissionDeniedException;
 import com.google.auth.oauth2.UserCredentials;
 import com.google.common.base.CaseFormat;
-import com.google.protobuf.Descriptors;
 import com.google.protobuf.AbstractMessage;
+import com.google.protobuf.Descriptors;
 import com.google.protobuf.util.JsonFormat;
 
 import org.embulk.util.config.units.ColumnConfig;

--- a/src/test/java/org/embulk/input/google_ads/TestGoogleAdsReporterFlattenResource.java
+++ b/src/test/java/org/embulk/input/google_ads/TestGoogleAdsReporterFlattenResource.java
@@ -1,0 +1,131 @@
+package org.embulk.input.google_ads;
+
+import com.google.ads.googleads.v24.resources.Campaign;
+import com.google.ads.googleads.v24.resources.AdGroup;
+import com.google.ads.googleads.v24.services.GoogleAdsRow;
+import org.embulk.util.config.units.ColumnConfig;
+import org.embulk.util.config.units.SchemaConfig;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tests for flattenResource with protobuf 4.x messages.
+ *
+ * Background: google-ads 43.x uses protobuf 4.x, where generated classes extend
+ * GeneratedMessage instead of GeneratedMessageV3. The previous instanceof GeneratedMessageV3
+ * check in flattenResource always returned false for v24 messages, preventing recursion
+ * into nested messages and causing all column values to be null.
+ *
+ * These tests do not use TestingEmbulk to avoid a pre-existing JAXB incompatibility
+ * with Java 11+. PluginTask and its dependencies are mocked with Mockito instead.
+ */
+public class TestGoogleAdsReporterFlattenResource
+{
+    private GoogleAdsReporter createReporter(String... columnNames)
+    {
+        PluginTask mockTask = Mockito.mock(PluginTask.class);
+        Mockito.when(mockTask.getClientId()).thenReturn("dummy");
+        Mockito.when(mockTask.getClientSecret()).thenReturn("dummy");
+        Mockito.when(mockTask.getRefreshToken()).thenReturn("dummy");
+
+        List<ColumnConfig> columns = new ArrayList<>();
+        for (String name : columnNames) {
+            ColumnConfig col = Mockito.mock(ColumnConfig.class);
+            Mockito.when(col.getName()).thenReturn(name);
+            columns.add(col);
+        }
+
+        SchemaConfig mockSchema = Mockito.mock(SchemaConfig.class);
+        Mockito.when(mockSchema.getColumns()).thenReturn(columns);
+        Mockito.when(mockTask.getFields()).thenReturn(mockSchema);
+
+        return new GoogleAdsReporter(mockTask);
+    }
+
+    @Test
+    public void testFlattenResourceExtractsNestedStringField()
+    {
+        GoogleAdsReporter reporter = createReporter("campaign.name");
+
+        Campaign campaign = Campaign.newBuilder().setName("test_campaign").build();
+        GoogleAdsRow row = GoogleAdsRow.newBuilder().setCampaign(campaign).build();
+
+        Map<String, String> result = new HashMap<>();
+        reporter.flattenResource(null, row.getAllFields(), result);
+
+        Assert.assertEquals("test_campaign", result.get("campaign.name"));
+    }
+
+    @Test
+    public void testFlattenResourceExtractsNestedLongField()
+    {
+        GoogleAdsReporter reporter = createReporter("campaign.id");
+
+        Campaign campaign = Campaign.newBuilder().setId(12345L).build();
+        GoogleAdsRow row = GoogleAdsRow.newBuilder().setCampaign(campaign).build();
+
+        Map<String, String> result = new HashMap<>();
+        reporter.flattenResource(null, row.getAllFields(), result);
+
+        Assert.assertEquals("12345", result.get("campaign.id"));
+    }
+
+    @Test
+    public void testFlattenResourceExtractsMultipleNestedFields()
+    {
+        GoogleAdsReporter reporter = createReporter("campaign.id", "campaign.name");
+
+        Campaign campaign = Campaign.newBuilder()
+                .setId(12345L)
+                .setName("test_campaign")
+                .build();
+        GoogleAdsRow row = GoogleAdsRow.newBuilder().setCampaign(campaign).build();
+
+        Map<String, String> result = new HashMap<>();
+        reporter.flattenResource(null, row.getAllFields(), result);
+
+        Assert.assertEquals("12345", result.get("campaign.id"));
+        Assert.assertEquals("test_campaign", result.get("campaign.name"));
+    }
+
+    @Test
+    public void testFlattenResourceExtractsFieldsFromMultipleResources()
+    {
+        GoogleAdsReporter reporter = createReporter("campaign.name", "ad_group.name");
+
+        Campaign campaign = Campaign.newBuilder().setName("test_campaign").build();
+        AdGroup adGroup = AdGroup.newBuilder().setName("test_ad_group").build();
+        GoogleAdsRow row = GoogleAdsRow.newBuilder()
+                .setCampaign(campaign)
+                .setAdGroup(adGroup)
+                .build();
+
+        Map<String, String> result = new HashMap<>();
+        reporter.flattenResource(null, row.getAllFields(), result);
+
+        Assert.assertEquals("test_campaign", result.get("campaign.name"));
+        Assert.assertEquals("test_ad_group", result.get("ad_group.name"));
+    }
+
+    @Test
+    public void testFlattenResourceReturnsNullForUnsetField()
+    {
+        GoogleAdsReporter reporter = createReporter("campaign.name");
+
+        // Campaign with no name set — protobuf default is empty string,
+        // which is omitted from getAllFields(), so the key won't appear in result.
+        Campaign campaign = Campaign.newBuilder().setId(1L).build();
+        GoogleAdsRow row = GoogleAdsRow.newBuilder().setCampaign(campaign).build();
+
+        Map<String, String> result = new HashMap<>();
+        reporter.flattenResource(null, row.getAllFields(), result);
+
+        Assert.assertNull(result.get("campaign.name"));
+    }
+}


### PR DESCRIPTION
## Problem

After upgrading google-ads to 43.2.0 (which uses protobuf 4.x), data was returned as null despite rows being present.

### Root cause

In protobuf 4.x, generated classes extend `GeneratedMessage` instead of `GeneratedMessageV3`. This broke two places in `GoogleAdsReporter`:

1. **`flattenResource`** — The `instanceof GeneratedMessageV3` check always returned `false`, so recursion into nested messages (e.g. `campaign` → `campaign.name`) never happened. The result map stayed empty, making all column values null.

2. **`convertMessageType`** — The `(GeneratedMessageV3)` cast threw `ClassCastException`, which was silently caught and returned null.

## Fix

Replace `GeneratedMessageV3` with `AbstractMessage`, which is the abstract base class inherited by all concrete protobuf messages in both 3.x and 4.x.

| Before | After |
|---|---|
| `import com.google.protobuf.GeneratedMessageV3` | `import com.google.protobuf.AbstractMessage` |
| `instanceof GeneratedMessageV3` | `instanceof AbstractMessage` |
| `(GeneratedMessageV3) fields.get(key)` | `(AbstractMessage) fields.get(key)` |
| `List<GeneratedMessageV3>` | `List<AbstractMessage>` |

## Related

- Follows #60 (google-ads 39.0.0 → 43.2.0 / API v21 → v24)
- Related issue: https://github.com/primenumber-dev/n-transfer-ui/issues/43046