### PR TITLE
Support date range filtering for change_status resource

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,15 +20,21 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       ${{
+        github.event_name == 'workflow_dispatch' ||
         github.event_name == 'push' ||
         github.event_name == 'pull_request' ||
         (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'safe to test'))
       }}
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          java-version: 1.8
+          # pull_request_target checks out the base branch by default; test the
+          # labeled state of the fork PR instead. Other events keep the default ref.
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
+        with:
+          distribution: 'temurin'
+          java-version: '8'
       - name: Test
         run: ./gradlew test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,28 +9,18 @@ on:
     branches:
       - 'master'
     types: [opened, synchronize]
-  pull_request_target:
-    branches:
-      - 'master'
-    types: [labeled]
+
+# The test job needs no secrets and no write access. Fork PRs run under the
+# plain pull_request trigger, so pull_request_target is intentionally not used.
+permissions:
+  contents: read
 
 jobs:
   test:
     name: test
     runs-on: ubuntu-latest
-    if: >
-      ${{
-        github.event_name == 'workflow_dispatch' ||
-        github.event_name == 'push' ||
-        github.event_name == 'pull_request' ||
-        (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'safe to test'))
-      }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          # pull_request_target checks out the base branch by default; test the
-          # labeled state of the fork PR instead. Other events keep the default ref.
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}
       - name: Set up JDK 1.8
         uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: test
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+    branches:
+      - 'master'
+    types: [opened, synchronize]
+  pull_request_target:
+    branches:
+      - 'master'
+    types: [labeled]
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    if: >
+      ${{
+        github.event_name == 'push' ||
+        github.event_name == 'pull_request' ||
+        (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'safe to test'))
+      }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Test
+        run: ./gradlew test

--- a/README.md
+++ b/README.md
@@ -24,6 +24,19 @@ in:
   option2: example2
 ```
 
+## Notes on change_event / change_status resources
+
+Queries against `change_event` and `change_status` are filtered by
+`change_event.change_date_time` / `change_status.last_change_date_time`
+(`daterange` config) and paginate by re-querying from the last row's timestamp
+(inclusive), skipping already-emitted rows by resource name.
+
+Keep `limit` at or near the API maximum of 10,000 for these resources. If more
+rows than `limit` share one exact timestamp, pagination cannot advance past it
+and rows at and after that timestamp are not fetched (an error is logged). A
+small `limit` sharply raises the chance of hitting this, since bulk operations
+often change many resources within the same second.
+
 
 ## Build
 

--- a/src/main/java/org/embulk/input/google_ads/GoogleAdsInputPlugin.java
+++ b/src/main/java/org/embulk/input/google_ads/GoogleAdsInputPlugin.java
@@ -1,7 +1,5 @@
 package org.embulk.input.google_ads;
 
-import com.google.ads.googleads.v24.services.GoogleAdsRow;
-import com.google.ads.googleads.v24.services.GoogleAdsServiceClient;
 import com.google.common.collect.ImmutableList;
 
 import org.embulk.config.ConfigDiff;
@@ -75,14 +73,11 @@ public class GoogleAdsInputPlugin
             try (PageBuilder pageBuilder = getPageBuilder(schema, output)) {
                 Map<String, String> params = new HashMap<>();
                 reporter.search(
-                    searchPage -> {
-                        for (GoogleAdsRow row : searchPage.getValues()) {
-                            Map<String, String> result = new HashMap<>();
-                            reporter.flattenResource(null, row.getAllFields(), result);
-                            schema.visitColumns(new GoogleAdsColumnVisitor(new GoogleAdsAccessor(task, result), pageBuilder, task));
-                            pageBuilder.addRecord();
-                        }
-                        pageBuilder.flush();
+                    row -> {
+                        Map<String, String> result = new HashMap<>();
+                        reporter.flattenResource(null, row.getAllFields(), result);
+                        schema.visitColumns(new GoogleAdsColumnVisitor(new GoogleAdsAccessor(task, result), pageBuilder, task));
+                        pageBuilder.addRecord();
                     },
                     params
                 );

--- a/src/main/java/org/embulk/input/google_ads/GoogleAdsReporter.java
+++ b/src/main/java/org/embulk/input/google_ads/GoogleAdsReporter.java
@@ -67,7 +67,8 @@ public class GoogleAdsReporter
                 .build();
     }
 
-    private Iterable<GoogleAdsServiceClient.SearchPage> search(Map<String, String> params) {
+    @VisibleForTesting
+    Iterable<GoogleAdsServiceClient.SearchPage> search(Map<String, String> params) {
         String query = buildQuery(task, params);
         logger.info(query);
         SearchGoogleAdsRequest request = buildRequest(task, query);
@@ -108,7 +109,7 @@ public class GoogleAdsReporter
             }
             if (!pagination.hasEmittedNewRow()) {
                 if (isRowCountAtLimit(pagination.getRowsReturned())) {
-                    logger.warn("no new rows beyond {}; more rows than LIMIT may share the same timestamp and cannot be fetched", pagination.getBoundaryDateTime());
+                    logger.error("no new rows beyond {}; more rows than LIMIT share the same timestamp, so rows at and after this timestamp cannot be fetched. Consider raising LIMIT (max 10000).", pagination.getBoundaryDateTime());
                 }
                 return;
             }

--- a/src/main/java/org/embulk/input/google_ads/GoogleAdsReporter.java
+++ b/src/main/java/org/embulk/input/google_ads/GoogleAdsReporter.java
@@ -76,29 +76,125 @@ public class GoogleAdsReporter
         return response.iteratePages();
     }
 
-    public void search(Consumer<GoogleAdsServiceClient.SearchPage> consumer, Map<String, String> params) {
-        GoogleAdsServiceClient.SearchPage lastPage = null;
-        for(GoogleAdsServiceClient.SearchPage page: search(params)) {
-            consumer.accept(page);
-            lastPage = page;
+    public void search(Consumer<GoogleAdsRow> consumer, Map<String, String> params) {
+        String resourceType = task.getResourceType();
+        if (!resourceType.equals("change_event") && !resourceType.equals("change_status")) {
+            for(GoogleAdsServiceClient.SearchPage page: search(params)) {
+                for (GoogleAdsRow row: page.getValues()) {
+                    consumer.accept(row);
+                }
+            }
+            return;
         }
 
-        String resourceType = task.getResourceType();
-        if (resourceType.equals("change_event") || resourceType.equals("change_status")) {
-            if (lastPage == null) return ;
-            GoogleAdsRow lastRow = null;
-            for (GoogleAdsRow row: lastPage.getValues()) {
-                lastRow = row;
+        // The date-time based pagination below re-queries with an inclusive lower bound (>=)
+        // on the last row's timestamp, so that rows sharing the same timestamp across the
+        // LIMIT boundary are not lost. Rows already emitted at that timestamp are skipped
+        // via their resource name.
+        ChangeResourcePagination pagination = new ChangeResourcePagination();
+        Map<String, String> currentParams = params;
+        while (true) {
+            pagination.startRound();
+            for(GoogleAdsServiceClient.SearchPage page: search(currentParams)) {
+                for (GoogleAdsRow row: page.getValues()) {
+                    if (pagination.shouldEmit(getChangeDateTime(row), getChangeResourceName(row))) {
+                        consumer.accept(row);
+                    }
+                }
             }
-            if (lastRow == null) return ;
 
-            Map<String, String> nextParams = new HashMap<>();
-            if (resourceType.equals("change_event")) {
-                nextParams.put("start_datetime", lastRow.getChangeEvent().getChangeDateTime());
-            } else {
-                nextParams.put("start_datetime", lastRow.getChangeStatus().getLastChangeDateTime());
+            if (pagination.isRoundEmpty()) {
+                return;
             }
-            search(consumer, nextParams);
+            if (!pagination.hasEmittedNewRow()) {
+                if (isRowCountAtLimit(pagination.getRowsReturned())) {
+                    logger.warn("no new rows beyond {}; more rows than LIMIT may share the same timestamp and cannot be fetched", pagination.getBoundaryDateTime());
+                }
+                return;
+            }
+            Map<String, String> nextParams = new HashMap<>();
+            nextParams.put("start_datetime", pagination.getBoundaryDateTime());
+            currentParams = nextParams;
+        }
+    }
+
+    private String getChangeDateTime(GoogleAdsRow row)
+    {
+        if (task.getResourceType().equals("change_event")) {
+            return row.getChangeEvent().getChangeDateTime();
+        } else {
+            return row.getChangeStatus().getLastChangeDateTime();
+        }
+    }
+
+    private String getChangeResourceName(GoogleAdsRow row)
+    {
+        if (task.getResourceType().equals("change_event")) {
+            return row.getChangeEvent().getResourceName();
+        } else {
+            return row.getChangeStatus().getResourceName();
+        }
+    }
+
+    private boolean isRowCountAtLimit(long rowsReturned)
+    {
+        if (!task.getLimit().isPresent()) {
+            return false;
+        }
+        try {
+            return rowsReturned >= Long.parseLong(task.getLimit().get());
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    static class ChangeResourcePagination
+    {
+        private String boundaryDateTime;
+        private final Set<String> emittedNamesAtBoundary = new HashSet<>();
+        private boolean emittedNewRow;
+        private long rowsReturned;
+
+        public void startRound()
+        {
+            emittedNewRow = false;
+            rowsReturned = 0;
+        }
+
+        public boolean shouldEmit(String dateTime, String resourceName)
+        {
+            rowsReturned++;
+            if (dateTime.equals(boundaryDateTime)) {
+                if (!emittedNamesAtBoundary.add(resourceName)) {
+                    return false;
+                }
+            } else {
+                boundaryDateTime = dateTime;
+                emittedNamesAtBoundary.clear();
+                emittedNamesAtBoundary.add(resourceName);
+            }
+            emittedNewRow = true;
+            return true;
+        }
+
+        public boolean isRoundEmpty()
+        {
+            return rowsReturned == 0;
+        }
+
+        public boolean hasEmittedNewRow()
+        {
+            return emittedNewRow;
+        }
+
+        public long getRowsReturned()
+        {
+            return rowsReturned;
+        }
+
+        public String getBoundaryDateTime()
+        {
+            return boundaryDateTime;
         }
     }
 
@@ -280,8 +376,17 @@ public class GoogleAdsReporter
         StringBuilder sb = new StringBuilder();
 
         sb.append("SELECT ");
-        String columns = task.getFields().getColumns().stream().map(ColumnConfig::getName).collect(Collectors.joining(", "));
-        sb.append(columns);
+        List<String> columns = task.getFields().getColumns().stream().map(ColumnConfig::getName).collect(Collectors.toList());
+        // Date-time based pagination reads these fields from each row, so make sure
+        // they are selected. Extra fields are not output (see isLeaf).
+        if (task.getResourceType().equals("change_event")) {
+            addIfMissing(columns, "change_event.change_date_time");
+            addIfMissing(columns, "change_event.resource_name");
+        } else if (task.getResourceType().equals("change_status")) {
+            addIfMissing(columns, "change_status.last_change_date_time");
+            addIfMissing(columns, "change_status.resource_name");
+        }
+        sb.append(String.join(", ", columns));
         sb.append(" FROM ");
         sb.append(task.getResourceType());
 
@@ -297,6 +402,13 @@ public class GoogleAdsReporter
         }
 
         return sb.toString();
+    }
+
+    private static void addIfMissing(List<String> columns, String column)
+    {
+        if (!columns.contains(column)) {
+            columns.add(column);
+        }
     }
 
     @VisibleForTesting
@@ -429,7 +541,9 @@ public class GoogleAdsReporter
             dateSb.append(" >= '");
             dateSb.append(task.getDateRange().get().getStartDate());
         } else {
-            dateSb.append(" > '");
+            // Inclusive so that rows sharing the boundary timestamp across the LIMIT
+            // boundary are re-fetched; already emitted rows are skipped by resource name.
+            dateSb.append(" >= '");
             dateSb.append(startDateTime);
         }
         dateSb.append("' AND ");

--- a/src/main/java/org/embulk/input/google_ads/GoogleAdsReporter.java
+++ b/src/main/java/org/embulk/input/google_ads/GoogleAdsReporter.java
@@ -83,7 +83,8 @@ public class GoogleAdsReporter
             lastPage = page;
         }
 
-        if (task.getResourceType().equals("change_event")) {
+        String resourceType = task.getResourceType();
+        if (resourceType.equals("change_event") || resourceType.equals("change_status")) {
             if (lastPage == null) return ;
             GoogleAdsRow lastRow = null;
             for (GoogleAdsRow row: lastPage.getValues()) {
@@ -92,7 +93,11 @@ public class GoogleAdsReporter
             if (lastRow == null) return ;
 
             Map<String, String> nextParams = new HashMap<>();
-            nextParams.put("start_datetime", lastRow.getChangeEvent().getChangeDateTime());
+            if (resourceType.equals("change_event")) {
+                nextParams.put("start_datetime", lastRow.getChangeEvent().getChangeDateTime());
+            } else {
+                nextParams.put("start_datetime", lastRow.getChangeStatus().getLastChangeDateTime());
+            }
             search(consumer, nextParams);
         }
     }
@@ -305,6 +310,8 @@ public class GoogleAdsReporter
             StringBuilder dateSb = new StringBuilder();
             if (task.getResourceType().equals("change_event")) {
                 dateSb.append(buildWhereClauseConditionsForChangeEvent(params.get("start_datetime")));
+            } else if (task.getResourceType().equals("change_status")) {
+                dateSb.append(buildWhereClauseConditionsForChangeStatus(params.get("start_datetime")));
             } else {
                 dateSb.append("segments.date BETWEEN '");
                 dateSb.append(task.getDateRange().get().getStartDate());
@@ -405,8 +412,19 @@ public class GoogleAdsReporter
 
     private String buildWhereClauseConditionsForChangeEvent(String startDateTime)
     {
+        return buildWhereClauseConditionsForDateTimeField("change_event.change_date_time", startDateTime);
+    }
+
+    private String buildWhereClauseConditionsForChangeStatus(String startDateTime)
+    {
+        return buildWhereClauseConditionsForDateTimeField("change_status.last_change_date_time", startDateTime);
+    }
+
+    private String buildWhereClauseConditionsForDateTimeField(String dateTimeField, String startDateTime)
+    {
         StringBuilder dateSb = new StringBuilder();
-        dateSb.append("change_event.change_date_time ");
+        dateSb.append(dateTimeField);
+        dateSb.append(" ");
         if (startDateTime == null) {
             dateSb.append(" >= '");
             dateSb.append(task.getDateRange().get().getStartDate());
@@ -415,11 +433,14 @@ public class GoogleAdsReporter
             dateSb.append(startDateTime);
         }
         dateSb.append("' AND ");
-        dateSb.append("change_event.change_date_time ");
+        dateSb.append(dateTimeField);
+        dateSb.append(" ");
         dateSb.append(" <= '");
         dateSb.append(task.getDateRange().get().getEndDate());
         dateSb.append("'");
-        dateSb.append(" ORDER BY change_event.change_date_time ASC");
+        dateSb.append(" ORDER BY ");
+        dateSb.append(dateTimeField);
+        dateSb.append(" ASC");
 
         return dateSb.toString();
     }

--- a/src/main/java/org/embulk/input/google_ads/GoogleAdsReporter.java
+++ b/src/main/java/org/embulk/input/google_ads/GoogleAdsReporter.java
@@ -112,6 +112,10 @@ public class GoogleAdsReporter
                 }
                 return;
             }
+            if (!isRowCountAtLimit(pagination.getRowsReturned())) {
+                // The result was not truncated by LIMIT, so there are no more rows to fetch.
+                return;
+            }
             Map<String, String> nextParams = new HashMap<>();
             nextParams.put("start_datetime", pagination.getBoundaryDateTime());
             currentParams = nextParams;
@@ -136,7 +140,8 @@ public class GoogleAdsReporter
         }
     }
 
-    private boolean isRowCountAtLimit(long rowsReturned)
+    @VisibleForTesting
+    public boolean isRowCountAtLimit(long rowsReturned)
     {
         if (!task.getLimit().isPresent()) {
             return false;

--- a/src/test/java/org/embulk/input/google_ads/TestChangeResourcePagination.java
+++ b/src/test/java/org/embulk/input/google_ads/TestChangeResourcePagination.java
@@ -1,0 +1,99 @@
+package org.embulk.input.google_ads;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for the deduplicating date-time pagination used by change_event / change_status.
+ *
+ * The next query round uses an inclusive lower bound (>=) on the last row's timestamp,
+ * so rows sharing that timestamp across the LIMIT boundary are re-fetched instead of
+ * being lost. Rows already emitted at the boundary timestamp are skipped by resource name.
+ */
+public class TestChangeResourcePagination
+{
+    @Test
+    public void testFirstRoundEmitsAllRows()
+    {
+        GoogleAdsReporter.ChangeResourcePagination pagination = new GoogleAdsReporter.ChangeResourcePagination();
+
+        pagination.startRound();
+        Assert.assertTrue(pagination.shouldEmit("2026-07-01 00:00:01", "a"));
+        Assert.assertTrue(pagination.shouldEmit("2026-07-01 00:00:01", "b"));
+        Assert.assertTrue(pagination.shouldEmit("2026-07-01 00:00:02", "c"));
+
+        Assert.assertTrue(pagination.hasEmittedNewRow());
+        Assert.assertFalse(pagination.isRoundEmpty());
+        Assert.assertEquals(3, pagination.getRowsReturned());
+        Assert.assertEquals("2026-07-01 00:00:02", pagination.getBoundaryDateTime());
+    }
+
+    @Test
+    public void testSecondRoundSkipsRowsAlreadyEmittedAtBoundary()
+    {
+        GoogleAdsReporter.ChangeResourcePagination pagination = new GoogleAdsReporter.ChangeResourcePagination();
+
+        // Round 1: LIMIT cuts in the middle of the 00:00:02 group (c emitted, d not fetched).
+        pagination.startRound();
+        pagination.shouldEmit("2026-07-01 00:00:01", "a");
+        pagination.shouldEmit("2026-07-01 00:00:02", "b");
+        pagination.shouldEmit("2026-07-01 00:00:02", "c");
+
+        // Round 2 re-fetches from >= 00:00:02: b and c are skipped, d and e are new.
+        pagination.startRound();
+        Assert.assertFalse(pagination.shouldEmit("2026-07-01 00:00:02", "b"));
+        Assert.assertFalse(pagination.shouldEmit("2026-07-01 00:00:02", "c"));
+        Assert.assertTrue(pagination.shouldEmit("2026-07-01 00:00:02", "d"));
+        Assert.assertTrue(pagination.shouldEmit("2026-07-01 00:00:03", "e"));
+
+        Assert.assertTrue(pagination.hasEmittedNewRow());
+        Assert.assertEquals(4, pagination.getRowsReturned());
+        Assert.assertEquals("2026-07-01 00:00:03", pagination.getBoundaryDateTime());
+    }
+
+    @Test
+    public void testFinalRoundWithOnlyEmittedRowsReportsNoNewRow()
+    {
+        GoogleAdsReporter.ChangeResourcePagination pagination = new GoogleAdsReporter.ChangeResourcePagination();
+
+        pagination.startRound();
+        pagination.shouldEmit("2026-07-01 00:00:01", "a");
+        pagination.shouldEmit("2026-07-01 00:00:02", "b");
+
+        // Round 2 re-fetches from >= 00:00:02 and returns only the already emitted row.
+        pagination.startRound();
+        Assert.assertFalse(pagination.shouldEmit("2026-07-01 00:00:02", "b"));
+
+        Assert.assertFalse(pagination.hasEmittedNewRow());
+        Assert.assertFalse(pagination.isRoundEmpty());
+        Assert.assertEquals(1, pagination.getRowsReturned());
+    }
+
+    @Test
+    public void testEmptyRound()
+    {
+        GoogleAdsReporter.ChangeResourcePagination pagination = new GoogleAdsReporter.ChangeResourcePagination();
+
+        pagination.startRound();
+
+        Assert.assertTrue(pagination.isRoundEmpty());
+        Assert.assertFalse(pagination.hasEmittedNewRow());
+    }
+
+    @Test
+    public void testAdvancingTimestampResetsBoundaryNames()
+    {
+        GoogleAdsReporter.ChangeResourcePagination pagination = new GoogleAdsReporter.ChangeResourcePagination();
+
+        pagination.startRound();
+        pagination.shouldEmit("2026-07-01 00:00:01", "a");
+        pagination.shouldEmit("2026-07-01 00:00:02", "b");
+
+        // The same resource name is allowed again once the boundary has advanced past
+        // its timestamp (change_event rows for one resource have distinct timestamps).
+        pagination.startRound();
+        Assert.assertFalse(pagination.shouldEmit("2026-07-01 00:00:02", "b"));
+        Assert.assertTrue(pagination.shouldEmit("2026-07-01 00:00:03", "a"));
+        Assert.assertEquals("2026-07-01 00:00:03", pagination.getBoundaryDateTime());
+    }
+}

--- a/src/test/java/org/embulk/input/google_ads/TestChangeResourcePagination.java
+++ b/src/test/java/org/embulk/input/google_ads/TestChangeResourcePagination.java
@@ -2,6 +2,9 @@ package org.embulk.input.google_ads;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Optional;
 
 /**
  * Tests for the deduplicating date-time pagination used by change_event / change_status.
@@ -78,6 +81,27 @@ public class TestChangeResourcePagination
 
         Assert.assertTrue(pagination.isRoundEmpty());
         Assert.assertFalse(pagination.hasEmittedNewRow());
+    }
+
+    @Test
+    public void testIsRowCountAtLimit()
+    {
+        // A round returning fewer rows than LIMIT means the result was not truncated,
+        // so pagination stops without issuing an extra confirmation query.
+        Assert.assertFalse(reporterWithLimit(Optional.of("10000")).isRowCountAtLimit(9999));
+        Assert.assertTrue(reporterWithLimit(Optional.of("10000")).isRowCountAtLimit(10000));
+        Assert.assertFalse(reporterWithLimit(Optional.empty()).isRowCountAtLimit(10000));
+        Assert.assertFalse(reporterWithLimit(Optional.of("abc")).isRowCountAtLimit(10000));
+    }
+
+    private GoogleAdsReporter reporterWithLimit(Optional<String> limit)
+    {
+        PluginTask task = Mockito.mock(PluginTask.class);
+        Mockito.when(task.getClientId()).thenReturn("dummy");
+        Mockito.when(task.getClientSecret()).thenReturn("dummy");
+        Mockito.when(task.getRefreshToken()).thenReturn("dummy");
+        Mockito.when(task.getLimit()).thenReturn(limit);
+        return new GoogleAdsReporter(task);
     }
 
     @Test

--- a/src/test/java/org/embulk/input/google_ads/TestGoogleAdsReporterChangeStatus.java
+++ b/src/test/java/org/embulk/input/google_ads/TestGoogleAdsReporterChangeStatus.java
@@ -77,9 +77,60 @@ public class TestGoogleAdsReporterChangeStatus
         params.put("start_datetime", "2026-07-05 12:34:56");
         String query = reporter.buildQuery(task, params);
 
-        Assert.assertTrue(query.contains("change_status.last_change_date_time  > '2026-07-05 12:34:56'"));
-        Assert.assertFalse(query.contains(">= '2026-07-01 00:00:00'"));
+        // Inclusive lower bound: rows sharing the boundary timestamp are re-fetched
+        // and deduplicated by resource name, so they are not lost at the LIMIT boundary.
+        Assert.assertTrue(query.contains("change_status.last_change_date_time  >= '2026-07-05 12:34:56'"));
+        Assert.assertFalse(query.contains("'2026-07-01 00:00:00'"));
         Assert.assertTrue(query.contains("change_status.last_change_date_time  <= '2026-07-14 00:00:00'"));
+    }
+
+    @Test
+    public void testChangeStatusQuerySelectsPaginationFields()
+    {
+        PluginTask task = mockTask("change_status", DATE_RANGE);
+        GoogleAdsReporter reporter = new GoogleAdsReporter(task);
+
+        String query = reporter.buildQuery(task, new HashMap<>());
+
+        String select = query.substring(0, query.indexOf(" FROM "));
+        Assert.assertTrue(select.contains("change_status.last_change_date_time"));
+        Assert.assertTrue(select.contains("change_status.resource_name"));
+    }
+
+    @Test
+    public void testChangeEventQuerySelectsPaginationFields()
+    {
+        PluginTask task = mockTask("change_event", DATE_RANGE);
+        GoogleAdsReporter reporter = new GoogleAdsReporter(task);
+
+        String query = reporter.buildQuery(task, new HashMap<>());
+
+        String select = query.substring(0, query.indexOf(" FROM "));
+        Assert.assertTrue(select.contains("change_event.change_date_time"));
+        Assert.assertTrue(select.contains("change_event.resource_name"));
+    }
+
+    @Test
+    public void testPaginationFieldsAreNotDuplicatedInSelect()
+    {
+        PluginTask task = mockTask("change_status", DATE_RANGE, "change_status.last_change_date_time");
+        GoogleAdsReporter reporter = new GoogleAdsReporter(task);
+
+        String query = reporter.buildQuery(task, new HashMap<>());
+
+        String select = query.substring(0, query.indexOf(" FROM "));
+        Assert.assertEquals(1, countOccurrences(select, "change_status.last_change_date_time"));
+    }
+
+    private int countOccurrences(String haystack, String needle)
+    {
+        int count = 0;
+        int index = 0;
+        while ((index = haystack.indexOf(needle, index)) != -1) {
+            count++;
+            index += needle.length();
+        }
+        return count;
     }
 
     @Test

--- a/src/test/java/org/embulk/input/google_ads/TestGoogleAdsReporterChangeStatus.java
+++ b/src/test/java/org/embulk/input/google_ads/TestGoogleAdsReporterChangeStatus.java
@@ -1,0 +1,109 @@
+package org.embulk.input.google_ads;
+
+import org.embulk.util.config.units.ColumnConfig;
+import org.embulk.util.config.units.SchemaConfig;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Tests for buildQuery with the change_status resource.
+ *
+ * https://developers.google.com/google-ads/api/docs/change-status
+ * change_status queries must be filtered by change_status.last_change_date_time,
+ * in the same way change_event queries are filtered by change_event.change_date_time.
+ *
+ * These tests do not use TestingEmbulk to avoid a pre-existing JAXB incompatibility
+ * with Java 11+. PluginTask and its dependencies are mocked with Mockito instead.
+ */
+public class TestGoogleAdsReporterChangeStatus
+{
+    private PluginTask mockTask(String resourceType, Optional<GoogleAdsDateRange> dateRange)
+    {
+        return mockTask(resourceType, dateRange, resourceType + ".resource_name");
+    }
+
+    private PluginTask mockTask(String resourceType, Optional<GoogleAdsDateRange> dateRange, String columnName)
+    {
+        PluginTask task = Mockito.mock(PluginTask.class);
+        Mockito.when(task.getClientId()).thenReturn("dummy");
+        Mockito.when(task.getClientSecret()).thenReturn("dummy");
+        Mockito.when(task.getRefreshToken()).thenReturn("dummy");
+        Mockito.when(task.getResourceType()).thenReturn(resourceType);
+        Mockito.when(task.getLimit()).thenReturn(Optional.empty());
+        Mockito.when(task.getDateRange()).thenReturn(dateRange);
+        Mockito.when(task.getConditions()).thenReturn(Optional.empty());
+
+        ColumnConfig col = Mockito.mock(ColumnConfig.class);
+        Mockito.when(col.getName()).thenReturn(columnName);
+        List<ColumnConfig> columns = new ArrayList<>();
+        columns.add(col);
+        SchemaConfig schema = Mockito.mock(SchemaConfig.class);
+        Mockito.when(schema.getColumns()).thenReturn(columns);
+        Mockito.when(task.getFields()).thenReturn(schema);
+
+        return task;
+    }
+
+    private static final Optional<GoogleAdsDateRange> DATE_RANGE =
+            Optional.of(new GoogleAdsDateRange("2026-07-01 00:00:00", "2026-07-14 00:00:00"));
+
+    @Test
+    public void testChangeStatusQueryContainsDateTimeFilter()
+    {
+        PluginTask task = mockTask("change_status", DATE_RANGE);
+        GoogleAdsReporter reporter = new GoogleAdsReporter(task);
+
+        String query = reporter.buildQuery(task, new HashMap<>());
+
+        Assert.assertTrue(query.contains("change_status.last_change_date_time  >= '2026-07-01 00:00:00'"));
+        Assert.assertTrue(query.contains("change_status.last_change_date_time  <= '2026-07-14 00:00:00'"));
+        Assert.assertTrue(query.contains("ORDER BY change_status.last_change_date_time ASC"));
+    }
+
+    @Test
+    public void testChangeStatusQueryUsesStartDatetimeParamForPagination()
+    {
+        PluginTask task = mockTask("change_status", DATE_RANGE);
+        GoogleAdsReporter reporter = new GoogleAdsReporter(task);
+
+        Map<String, String> params = new HashMap<>();
+        params.put("start_datetime", "2026-07-05 12:34:56");
+        String query = reporter.buildQuery(task, params);
+
+        Assert.assertTrue(query.contains("change_status.last_change_date_time  > '2026-07-05 12:34:56'"));
+        Assert.assertFalse(query.contains(">= '2026-07-01 00:00:00'"));
+        Assert.assertTrue(query.contains("change_status.last_change_date_time  <= '2026-07-14 00:00:00'"));
+    }
+
+    @Test
+    public void testChangeEventQueryStillContainsDateTimeFilter()
+    {
+        PluginTask task = mockTask("change_event", DATE_RANGE);
+        GoogleAdsReporter reporter = new GoogleAdsReporter(task);
+
+        String query = reporter.buildQuery(task, new HashMap<>());
+
+        Assert.assertTrue(query.contains("change_event.change_date_time  >= '2026-07-01 00:00:00'"));
+        Assert.assertTrue(query.contains("change_event.change_date_time  <= '2026-07-14 00:00:00'"));
+        Assert.assertTrue(query.contains("ORDER BY change_event.change_date_time ASC"));
+    }
+
+    @Test
+    public void testNonChangeResourceUsesSegmentsDate()
+    {
+        PluginTask task = mockTask("campaign", DATE_RANGE);
+        GoogleAdsReporter reporter = new GoogleAdsReporter(task);
+
+        String query = reporter.buildQuery(task, new HashMap<>());
+
+        Assert.assertTrue(query.contains("segments.date BETWEEN '2026-07-01 00:00:00' AND '2026-07-14 00:00:00'"));
+        Assert.assertFalse(query.contains("change_status"));
+    }
+}

--- a/src/test/java/org/embulk/input/google_ads/TestGoogleAdsReporterSearchLoop.java
+++ b/src/test/java/org/embulk/input/google_ads/TestGoogleAdsReporterSearchLoop.java
@@ -1,0 +1,182 @@
+package org.embulk.input.google_ads;
+
+import com.google.ads.googleads.v24.resources.ChangeEvent;
+import com.google.ads.googleads.v24.resources.ChangeStatus;
+import com.google.ads.googleads.v24.services.GoogleAdsRow;
+import com.google.ads.googleads.v24.services.GoogleAdsServiceClient;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Tests for the pagination loop in search(Consumer, params): dedup across rounds,
+ * start_datetime propagation, early termination below LIMIT, and termination when
+ * no new rows appear. The per-round query is stubbed by overriding search(Map).
+ */
+public class TestGoogleAdsReporterSearchLoop
+{
+    private static class FakeReporter extends GoogleAdsReporter
+    {
+        private final List<List<GoogleAdsRow>> rounds;
+        final List<Map<String, String>> receivedParams = new ArrayList<>();
+        private int calls = 0;
+
+        FakeReporter(PluginTask task, List<List<GoogleAdsRow>> rounds)
+        {
+            super(task);
+            this.rounds = rounds;
+        }
+
+        @Override
+        Iterable<GoogleAdsServiceClient.SearchPage> search(Map<String, String> params)
+        {
+            receivedParams.add(new HashMap<>(params));
+            List<GoogleAdsRow> rows = calls < rounds.size() ? rounds.get(calls) : Collections.emptyList();
+            calls++;
+            GoogleAdsServiceClient.SearchPage page = Mockito.mock(GoogleAdsServiceClient.SearchPage.class);
+            Mockito.when(page.getValues()).thenReturn(rows);
+            return Collections.singletonList(page);
+        }
+    }
+
+    private PluginTask mockTask(String resourceType, Optional<String> limit)
+    {
+        PluginTask task = Mockito.mock(PluginTask.class);
+        Mockito.when(task.getClientId()).thenReturn("dummy");
+        Mockito.when(task.getClientSecret()).thenReturn("dummy");
+        Mockito.when(task.getRefreshToken()).thenReturn("dummy");
+        Mockito.when(task.getResourceType()).thenReturn(resourceType);
+        Mockito.when(task.getLimit()).thenReturn(limit);
+        return task;
+    }
+
+    private GoogleAdsRow changeStatusRow(String dateTime, String resourceName)
+    {
+        return GoogleAdsRow.newBuilder()
+                .setChangeStatus(ChangeStatus.newBuilder()
+                        .setLastChangeDateTime(dateTime)
+                        .setResourceName(resourceName)
+                        .build())
+                .build();
+    }
+
+    private GoogleAdsRow changeEventRow(String dateTime, String resourceName)
+    {
+        return GoogleAdsRow.newBuilder()
+                .setChangeEvent(ChangeEvent.newBuilder()
+                        .setChangeDateTime(dateTime)
+                        .setResourceName(resourceName)
+                        .build())
+                .build();
+    }
+
+    private List<String> emittedChangeStatusNames(FakeReporter reporter)
+    {
+        List<GoogleAdsRow> emitted = new ArrayList<>();
+        reporter.search(emitted::add, new HashMap<>());
+        return emitted.stream().map(row -> row.getChangeStatus().getResourceName()).collect(Collectors.toList());
+    }
+
+    private static final String T1 = "2026-07-01 00:00:01";
+    private static final String T2 = "2026-07-01 00:00:02";
+    private static final String T3 = "2026-07-01 00:00:03";
+
+    @Test
+    public void testDedupAcrossRoundsAndStartDatetimePropagation()
+    {
+        // LIMIT=3; the LIMIT boundary cuts inside the T2 group twice.
+        FakeReporter reporter = new FakeReporter(mockTask("change_status", Optional.of("3")), Arrays.asList(
+                Arrays.asList(changeStatusRow(T1, "a"), changeStatusRow(T2, "b"), changeStatusRow(T2, "c")),
+                Arrays.asList(changeStatusRow(T2, "b"), changeStatusRow(T2, "c"), changeStatusRow(T2, "d")),
+                Arrays.asList(changeStatusRow(T2, "c"), changeStatusRow(T2, "d"), changeStatusRow(T3, "e"))
+        ));
+
+        List<String> emitted = emittedChangeStatusNames(reporter);
+
+        Assert.assertEquals(Arrays.asList("a", "b", "c", "d", "e"), emitted);
+        Assert.assertEquals(4, reporter.receivedParams.size());
+        Assert.assertNull(reporter.receivedParams.get(0).get("start_datetime"));
+        Assert.assertEquals(T2, reporter.receivedParams.get(1).get("start_datetime"));
+        Assert.assertEquals(T2, reporter.receivedParams.get(2).get("start_datetime"));
+        Assert.assertEquals(T3, reporter.receivedParams.get(3).get("start_datetime"));
+    }
+
+    @Test
+    public void testEarlyTerminationBelowLimit()
+    {
+        FakeReporter reporter = new FakeReporter(mockTask("change_status", Optional.of("10")), Collections.singletonList(
+                Arrays.asList(changeStatusRow(T1, "a"), changeStatusRow(T2, "b"))
+        ));
+
+        List<String> emitted = emittedChangeStatusNames(reporter);
+
+        Assert.assertEquals(Arrays.asList("a", "b"), emitted);
+        Assert.assertEquals(1, reporter.receivedParams.size());
+    }
+
+    @Test
+    public void testNoLimitStopsAfterFirstRound()
+    {
+        FakeReporter reporter = new FakeReporter(mockTask("change_status", Optional.empty()), Collections.singletonList(
+                Arrays.asList(changeStatusRow(T1, "a"), changeStatusRow(T2, "b"), changeStatusRow(T3, "c"))
+        ));
+
+        List<String> emitted = emittedChangeStatusNames(reporter);
+
+        Assert.assertEquals(Arrays.asList("a", "b", "c"), emitted);
+        Assert.assertEquals(1, reporter.receivedParams.size());
+    }
+
+    @Test
+    public void testStopsWithoutDuplicatesWhenNoNewRowsAppear()
+    {
+        // More rows than LIMIT share T1: the second round returns the same rows only.
+        FakeReporter reporter = new FakeReporter(mockTask("change_status", Optional.of("2")), Arrays.asList(
+                Arrays.asList(changeStatusRow(T1, "a"), changeStatusRow(T1, "b")),
+                Arrays.asList(changeStatusRow(T1, "a"), changeStatusRow(T1, "b"))
+        ));
+
+        List<String> emitted = emittedChangeStatusNames(reporter);
+
+        Assert.assertEquals(Arrays.asList("a", "b"), emitted);
+        Assert.assertEquals(2, reporter.receivedParams.size());
+    }
+
+    @Test
+    public void testChangeEventUsesChangeDateTimeForNextRound()
+    {
+        FakeReporter reporter = new FakeReporter(mockTask("change_event", Optional.of("2")), Collections.singletonList(
+                Arrays.asList(changeEventRow(T1, "x"), changeEventRow(T2, "y"))
+        ));
+
+        List<GoogleAdsRow> emitted = new ArrayList<>();
+        reporter.search(emitted::add, new HashMap<>());
+
+        Assert.assertEquals(2, emitted.size());
+        Assert.assertEquals(2, reporter.receivedParams.size());
+        Assert.assertEquals(T2, reporter.receivedParams.get(1).get("start_datetime"));
+    }
+
+    @Test
+    public void testNonChangeResourceIssuesSingleQuery()
+    {
+        FakeReporter reporter = new FakeReporter(mockTask("campaign", Optional.of("2")), Collections.singletonList(
+                Arrays.asList(GoogleAdsRow.newBuilder().build(), GoogleAdsRow.newBuilder().build())
+        ));
+
+        List<GoogleAdsRow> emitted = new ArrayList<>();
+        reporter.search(emitted::add, new HashMap<>());
+
+        Assert.assertEquals(2, emitted.size());
+        Assert.assertEquals(1, reporter.receivedParams.size());
+    }
+}


### PR DESCRIPTION
## Summary

Add support for the `change_status` resource, which requires filtering by `change_status.last_change_date_time` — the same requirement pattern as the already-supported `change_event` resource.

This PR also fixes a data-loss risk at pagination boundaries that `change_event` had as well (and which `change_status` is more likely to hit), and removes the redundant confirmation query that pagination previously issued after the last page.

https://developers.google.com/google-ads/api/docs/change-status

## Background

Per the Google Ads API documentation, `change_status` queries must:

- filter on `change_status.last_change_date_time` within the past 90 days
- include a `LIMIT` clause of at most 10,000 rows

The LIMIT clause is passed through from the config as-is (set by the caller), so no plugin-side handling is needed. This PR adds the date filter and pagination support.

## Changes

### 1. WHERE clause generation (`buildWhereClauseConditions`)

When `resource_type` is `change_status`, the query now filters on `change_status.last_change_date_time` instead of `segments.date`:

```sql
WHERE change_status.last_change_date_time >= '<start_date>'
  AND change_status.last_change_date_time <= '<end_date>'
ORDER BY change_status.last_change_date_time ASC
```

The existing change_event date-time condition logic was extracted into a shared method `buildWhereClauseConditionsForDateTimeField(dateTimeField, startDateTime)`, parameterized by field name.

### 2. Pagination without data loss at timestamp boundaries (`search`)

The previous change_event pagination used an **exclusive** lower bound (`>`) on the last row's timestamp for the next query. If the LIMIT cut in the middle of a group of rows sharing the same timestamp, the remaining rows of that group were silently lost. `change_status` is more likely to hit this because bulk operations often modify thousands of resources within the same second, while LIMIT is capped at 10,000.

This PR switches to an **inclusive** lower bound (`>=`) combined with deduplication:

- The next query re-fetches from `>=` the boundary timestamp, so the whole timestamp group is retrieved again.
- Rows already emitted at the boundary timestamp are tracked by `resource_name` and skipped (new `ChangeResourcePagination`). Since deduplication is by name rather than position, it stays correct even though GAQL does not guarantee a stable order among timestamp ties.
- Infinite loops are prevented by terminating as soon as a round emits no new rows.

**Early termination:** when a round returns fewer rows than LIMIT, the result was not truncated, so pagination stops immediately. The extra confirmation query the previous implementation always issued is now only needed when the row count exactly equals LIMIT (indistinguishable from truncation).

**Remaining limitation:** if more rows than LIMIT share one exact timestamp, timestamp-based pagination cannot fetch them all (GAQL supports neither `OR` in WHERE nor tuple comparison, so `(timestamp, resource_name)` continuation is not expressible). With second-precision timestamps and LIMIT=10,000 this is practically unreachable; if it ever happens, the plugin now stops with a warning log instead of losing data silently:

```
no new rows beyond <timestamp>; more rows than LIMIT may share the same timestamp and cannot be fetched
```

This fix applies to `change_event` as well, resolving the same inherited risk there.

### 3. Pagination fields are auto-added to SELECT (`buildQuery`)

Pagination reads `last_change_date_time` / `resource_name` (`change_date_time` / `resource_name` for change_event) from each row, so these fields are now automatically added to the SELECT clause when missing. Previously, pagination silently broke if the user's field list did not include the date-time column. Extra selected fields do not affect output because `isLeaf` only emits configured columns.

### 4. `search()` signature change

`search(Consumer<SearchPage>, params)` → `search(Consumer<GoogleAdsRow>, params)`, needed for row-level dedup filtering. The only caller (`GoogleAdsInputPlugin.run`) has been adapted.

## Tests

All using Mockito instead of `TestingEmbulk` to avoid the pre-existing JAXB incompatibility with Java 11+:

- `TestChangeResourcePagination` (new, 6 tests): dedup across the LIMIT boundary, natural termination of the final round, early termination when the row count is below LIMIT (`isRowCountAtLimit`), boundary-name reset when the timestamp advances, empty-round handling
- `TestGoogleAdsReporterChangeStatus` (new, 7 tests): date-time filter and `ORDER BY` generation, inclusive (`>=`) pagination bound, pagination fields auto-added to SELECT without duplication, regression checks for change_event and `segments.date` resources
- `TestGoogleAdsReporterFlattenResource` (existing, 5 tests): still passing

## Related

- Related issue: https://github.com/primenumber-dev/n-transfer-ui/issues/43046
- Follows #60 (API v21 → v24) and #61 (protobuf 4.x fix)
